### PR TITLE
Docker 環境で起動できるようにする仮修正

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,15 @@
 FROM ruby:2.6-alpine
 
+ENV RUBYGEMS_VERSION=2.7.6
+ENV BUNDLER_VERSION=1.16.6
+
 RUN mkdir -p /app
 WORKDIR /app
 
 COPY Gemfile.docker /app/Gemfile
 COPY Gemfile.lock /app/
 
-RUN gem install bundler
+RUN gem install bundler -v ${BUNDLER_VERSION}
 RUN apk add --no-cache bash nodejs mysql-client mysql-dev sqlite-dev less
 RUN apk add --no-cache alpine-sdk \
       --virtual .build_deps libxml2-dev libxslt-dev zlib zlib-dev \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,12 @@
-FROM ruby:2.6-alpine
+FROM ruby:3.4.1-alpine
 
-ENV RUBYGEMS_VERSION=2.7.6
-ENV BUNDLER_VERSION=1.16.6
+ENV RUBYGEMS_VERSION=3.6.2
+ENV BUNDLER_VERSION=2.6.2
 
 RUN mkdir -p /app
 WORKDIR /app
 
-COPY Gemfile.docker /app/Gemfile
-COPY Gemfile.lock /app/
+COPY . /app
 
 RUN gem install bundler -v ${BUNDLER_VERSION}
 RUN apk add --no-cache bash nodejs mysql-client mysql-dev sqlite-dev less
@@ -17,8 +16,5 @@ RUN apk add --no-cache alpine-sdk \
       && bundle install -j4 --without postgresql:sqlite \
       && apk del alpine-sdk .build_deps \
       && rm -rf /tmp/* /var/cache/apk/*
-
-COPY . /app
-COPY Gemfile.docker /app/Gemfile
 
 CMD ["bundle", "exec", "rackup", "-o", "0.0.0.0"]

--- a/Dockerfile.production
+++ b/Dockerfile.production
@@ -1,0 +1,22 @@
+FROM ruby:3.3.7-alpine
+
+ENV RUBYGEMS_VERSION=3.6.2
+ENV BUNDLER_VERSION=2.6.2
+ENV DATABASE_URL='mysql://root:password@db.local/lokka_production'
+
+RUN mkdir -p /app
+WORKDIR /app
+
+COPY . /app
+
+RUN gem install bundler -v ${BUNDLER_VERSION}
+RUN apk add --no-cache bash nodejs mysql-client mysql-dev sqlite-dev less xz-libs
+RUN apk add --no-cache alpine-sdk \
+      --virtual .build_deps libxml2-dev libxslt-dev zlib zlib-dev \
+      && cd /app \
+      && bundle install -j4 --without postgresql:sqlite \
+      && apk del alpine-sdk .build_deps \
+      && rm -rf /tmp/* /var/cache/apk/*
+RUN cp -p database.default.yml database.yml
+
+CMD ["bundle", "exec", "rackup", "-o", "0.0.0.0"]

--- a/Dockerfile.production
+++ b/Dockerfile.production
@@ -1,7 +1,7 @@
-FROM ruby:3.3.7-alpine
+FROM ruby:2.6.10-alpine
 
-ENV RUBYGEMS_VERSION=3.6.2
-ENV BUNDLER_VERSION=2.6.2
+ENV RUBYGEMS_VERSION=3.0.3.1
+ENV BUNDLER_VERSION=2.1.2
 ENV DATABASE_URL='mysql://root:password@db.local/lokka_production'
 
 RUN mkdir -p /app

--- a/Gemfile
+++ b/Gemfile
@@ -1,8 +1,8 @@
 source 'https://rubygems.org'
-ruby "~> 3.4"
+ruby "~> 3.3"
 
 gem 'activesupport', '~> 5.2'
-gem 'aws-sdk-s3'
+gem 'aws-sdk-s3', '~> 1.180'
 gem 'backports', '2.3.0'
 gem 'builder'
 gem 'bundler'
@@ -41,7 +41,8 @@ gem 'slim', '~> 3.0.7'
 gem 'tilt', '~> 2.0'
 gem 'tux'
 gem 'yard-sinatra', '1.0.0'
-gem 'ffi', '~>1.17'
+gem 'ffi', '~> 1.17'
+gem 'sorted_set'
 
 Dir['public/plugin/lokka-*/Gemfile'].each {|path| load(path) }
 

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,5 @@
 source 'https://rubygems.org'
-ruby "~> 3.3"
+ruby "~> 2.6"
 
 gem 'activesupport', '~> 5.2'
 gem 'aws-sdk-s3', '~> 1.180'
@@ -41,7 +41,7 @@ gem 'slim', '~> 3.0.7'
 gem 'tilt', '~> 2.0'
 gem 'tux'
 gem 'yard-sinatra', '1.0.0'
-gem 'ffi', '~> 1.17'
+gem 'ffi', '~> 1.16'
 gem 'sorted_set'
 
 Dir['public/plugin/lokka-*/Gemfile'].each {|path| load(path) }

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,5 @@
 source 'https://rubygems.org'
-ruby "~> 2.6"
+ruby "~> 3.4"
 
 gem 'activesupport', '~> 5.2'
 gem 'aws-sdk-s3'
@@ -41,6 +41,7 @@ gem 'slim', '~> 3.0.7'
 gem 'tilt', '~> 2.0'
 gem 'tux'
 gem 'yard-sinatra', '1.0.0'
+gem 'ffi', '~>1.17'
 
 Dir['public/plugin/lokka-*/Gemfile'].each {|path| load(path) }
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -289,4 +289,4 @@ RUBY VERSION
    ruby 2.7.0p0
 
 BUNDLED WITH
-   2.1.2
+   1.16.1

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -110,7 +110,7 @@ GEM
     factory_girl (4.9.0)
       activesupport (>= 3.0.0)
     fastercsv (1.5.5)
-    ffi (1.11.1)
+    ffi (1.17.1)
     haml (5.0.4)
       temple (>= 0.8.0)
       tilt
@@ -130,7 +130,7 @@ GEM
       rexml
     marcel (1.0.1)
     mini_portile2 (2.6.1)
-    minitest (5.14.1)
+    minitest (5.25.4)
     multi_json (1.12.2)
     nokogiri (1.12.5)
       mini_portile2 (~> 2.6.1)
@@ -259,6 +259,7 @@ DEPENDENCIES
   dm-validations (~> 1.2.0)
   erubis (~> 2.7.0)
   factory_girl (~> 4.0)
+  ffi (~> 1.17)
   haml (~> 5.0)
   haml-lint
   i18n (~> 0.7)
@@ -286,7 +287,7 @@ DEPENDENCIES
   yard-sinatra (= 1.0.0)
 
 RUBY VERSION
-   ruby 2.7.0p0
+   ruby 3.4.1p0
 
 BUNDLED WITH
-   1.16.1
+   2.6.2

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -110,7 +110,7 @@ GEM
     factory_girl (4.9.0)
       activesupport (>= 3.0.0)
     fastercsv (1.5.5)
-    ffi (1.17.1)
+    ffi (1.16.3)
     haml (5.0.4)
       temple (>= 0.8.0)
       tilt
@@ -259,7 +259,7 @@ DEPENDENCIES
   dm-validations (~> 1.2.0)
   erubis (~> 2.7.0)
   factory_girl (~> 4.0)
-  ffi (~> 1.17)
+  ffi (~> 1.16)
   haml (~> 5.0)
   haml-lint
   i18n (~> 0.7)
@@ -287,7 +287,7 @@ DEPENDENCIES
   yard-sinatra (= 1.0.0)
 
 RUBY VERSION
-   ruby 3.4.1p0
+   ruby 2.6.10
 
 BUNDLED WITH
    2.6.2

--- a/README.md
+++ b/README.md
@@ -53,6 +53,15 @@ $ docker-compose up
 
 open http://localhost:9292 on your browser.
 
+## [TEMPORARY] Deploy as Docker container
+
+```sh
+$ docker build -t lokka_production -f Dockerfile.production .
+$ mysqladmin -u root -p -h ${HOST IP} create lokka_production
+$ docker run -e DATABASE_URL='mysql://root:password@db.local/lokka_production' -e LOKKA_ENV=production --add-host=db.local:${HOST IP} -it lokka.production:latest rake db:setup
+$ docker run -e DATABASE_URL='mysql://root:password@db.local/lokka_production' -e LOKKA_ENV=production --add-host=db.local:${HOST IP} -p 8080:9292 -it lokka.production:latest
+```
+
 ## Test
 
 ```sh

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ services:
   db:
     image: mysql:5.7
     ports:
-      - "3306:3306"
+      - ${LOKKA_DB_PORT:-3306}:3306
     environment:
       MYSQL_ROOT_PASSWORD: password
       MYSQL_ALLOW_EMPTY_PASSWORD: 1
@@ -11,7 +11,7 @@ services:
     volumes:
       - data-volume:/var/lib/mysql
   app:
-    image: lokka/lokka
+    # image: lokka/lokka
     environment:
       DB_HOST: db
     build: .
@@ -21,7 +21,7 @@ services:
       - app_bundle:/app/.bundle
       - vendor:/app/vendor
     ports:
-      - "9292:9292"
+      - ${LOKKA_APP_PORT:-9292}:9292
     depends_on:
       - db
 volumes:


### PR DESCRIPTION
公式最新版のままでは起動できなかったので、一先ず自分の環境で起動できるように実装を整える。

元々起動できなかった原因が不明瞭なので、原因調査は必要。しかし、数年単位でメンテナンスされていないので、当時は起動できたが環境変化で起動不能になったのか、元々作業途中だったのかは、もはや追及できないかもしれない。
